### PR TITLE
Generate changelog and GitHub releases

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Required for Calculate Version step (e.g. GitVersion)
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,60 @@
+name: Release Notes
+
+on:
+  push:
+    branches: [ master, release* ]
+  pull_request:
+    branches: [ master, release* ]
+
+jobs:
+  generate-release-notes:
+    name: Generate Release Notes
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required for Calculate Version step (e.g. GitVersion)
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '5.12.0'
+
+      - name: GitVersion Config
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+          additionalArguments: '/showConfig'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+          additionalArguments: '/updateprojectfiles'
+
+      - name: Install GitReleaseManager
+        uses: gittools/actions/gitreleasemanager/setup@v0.10.2
+        with:
+          versionSpec: '0.13.0'
+
+      # If there are no closed issues generating the Github Release will fail because it raises an exception.
+      # Work around this by checking for success or no closed issue errors.
+      - name: Create Release ${{ steps.gitversion.outputs.majorMinorPatch }}
+        run: |
+          dotnet gitreleasemanager create --owner saturdaymp --repository NConstraints --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
+          cat output.txt | grep 'No closed issues have been found for milestone\|Drafted release is available at'
+
+      - name: 'Generate Change Log'
+        run: |
+          dotnet-gitreleasemanager export --token ${{ secrets.GITHUB_TOKEN }} -o 'saturdaymp' -r 'NConstraints' -f 'CHANGELOG.md'
+          git add --renormalize CHANGELOG.md
+          cat CHANGELOG.md
+
+      - name: 'Commit Change Log if it Changed'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Committing auto generated change log.
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -2,9 +2,9 @@ name: Release Notes
 
 on:
   push:
-    branches: [ master, release* ]
+    branches: [ main, release* ]
   pull_request:
-    branches: [ master, release* ]
+    branches: [ main, release* ]
 
 jobs:
   generate-release-notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.1.0 (07/18/2023 21:12:11 +00:00)
+## v1.1.0 (Jul, 18, 2023)
 
 
 As part of this release we had [3 issues](https://github.com/saturdaymp/NConstraints/milestone/1?closed=1) closed.
@@ -11,4 +11,6 @@ __DevOps__
 
 - [__#3__](https://github.com/saturdaymp/NConstraints/pull/3) Refactor project structure and file names
 - [__#4__](https://github.com/saturdaymp/NConstraints/pull/4) Create CI in GitHub Actions
+
+b Actions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## v1.1.0
+
+
+As part of this release we had [3 issues](https://github.com/saturdaymp/NConstraints/milestone/1?closed=1) closed.
+
+__Dependency__
+
+- [__#2__](https://github.com/saturdaymp/NConstraints/pull/2) Update project files and dependencies to .NET 6 and .NET Standard 2.0.
+
+__DevOps__
+
+- [__#3__](https://github.com/saturdaymp/NConstraints/pull/3) Refactor project structure and file names
+- [__#4__](https://github.com/saturdaymp/NConstraints/pull/4) Create CI in GitHub Actions
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.1.0
+## v1.1.0 (07/18/2023 21:12:11 +00:00)
 
 
 As part of this release we had [3 issues](https://github.com/saturdaymp/NConstraints/milestone/1?closed=1) closed.

--- a/GitReleaseManager.yml
+++ b/GitReleaseManager.yml
@@ -1,3 +1,6 @@
+export:
+  include-created-date-in-title: true
+
 issue-labels-include:
   - bug
   - devops

--- a/GitReleaseManager.yml
+++ b/GitReleaseManager.yml
@@ -1,5 +1,6 @@
 export:
   include-created-date-in-title: true
+  created-date-string-format: MMM, d, yyyy
 
 issue-labels-include:
   - bug

--- a/GitReleaseManager.yml
+++ b/GitReleaseManager.yml
@@ -1,0 +1,32 @@
+issue-labels-include:
+  - bug
+  - devops
+  - dependency
+  - documentation
+  - enhancement
+  - security
+
+issue-labels-alias:
+  - name: bug
+    header: Bug
+    plural: Bugs
+
+  - name: dependency
+    header: Dependency
+    plural: Dependencies
+
+  - name: devops
+    header: DevOps
+    plural: DevOps
+
+  - name: documentation
+    header: Documentation
+    plural: Documentation
+
+  - name: feature
+    header: Feature
+    plural: Feature
+
+  - name: security
+    header: Security
+    plural: Security


### PR DESCRIPTION
Add GitHub workflow that uses [GitReleaseManager](https://github.com/GitTools/GitReleaseManager) auto-generate the CHANGE.log and automatically create the GitHub release.  Aside from creating the both it will also update them as issues are closed.