### PR TITLE
Fix NUnit dependency so NConstratins works with any version of NUnit 3 instead of just the latest

### DIFF
--- a/SaturdayMP.NConstraints/SaturdayMP.NConstraints.csproj
+++ b/SaturdayMP.NConstraints/SaturdayMP.NConstraints.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="NUnit" Version="[3.0,4.0)" />
   </ItemGroup>
 
 </Project>

--- a/SaturdayMP.NConstraints/SaturdayMP.NConstraints.csproj
+++ b/SaturdayMP.NConstraints/SaturdayMP.NConstraints.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update the NConstraints dependency from a hard coded NUnit value to a any version of NUnit 3.